### PR TITLE
updated static-jade-brunch to the v1.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,6 @@ yo angular-brunch:provider
 ```
 
 
-## known Issues
-
-* [static-jade-brunch](https://github.com/ilkosta/static-jade-brunch): This library depends of **node 0.10** , if you have a later version, you'll get an error when running **brunch w**
-
 ## License
 
 MIT

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -11,7 +11,7 @@
     "css-brunch": ">= 1.0 < 1.8",
     "jade-brunch": "^1.8.1",
     "javascript-brunch": ">= 1.0 < 1.8",
-    "static-jade-brunch": "^1.7.0",
+    "static-jade-brunch": "^1.7.3",
     "uglify-js-brunch": ">= 1.0 < 1.8"
   },
   "scripts": {


### PR DESCRIPTION
I'm happy to see that static-jade-brunch can be useful.
I just wore the js hat and updated the old npm package. 

Unfortunately I'm no longer using Brunch, CoffeeScript and increasingly rarely JS.
I wish that those who find the jade-static-brunch useful can freely contribute to its development.

Let me know if you like to take part.
